### PR TITLE
Initial support for creating a variant from a parent variant which is…

### DIFF
--- a/lib/Oryzone/MediaStorage/MediaStorage.php
+++ b/lib/Oryzone/MediaStorage/MediaStorage.php
@@ -483,6 +483,39 @@ class MediaStorage implements MediaStorageInterface
                 $variant = $this->defaultVariant;
         }
 
+        if (!$media->hasVariant($variant)) {
+            // If this media does not have a variant based on its parent variant, if it has a parent
+            $filesystem = $this->getFilesystem($context->getFilesystemName());
+            $namingStrategy = $this->getNamingStrategy($context->getNamingStrategyName());
+            $context = $this->getContext($media->getContext());
+            $provider = $this->getProvider($context->getProviderName(), $context->getProviderOptions());
+            $variantsTree = $context->buildVariantTree();
+
+            /** @var $node VariantNode */
+            $node = $variantsTree->getNode($variant);
+            $childVariant = $node->getContent();
+            while ($node->getParent()) { // advance to parent node
+                $node = $node->getParent();
+            }
+
+            // Get parents variant information to base this new variant off
+            $parentVariant = $media->getVariantInstance($node->getContent()->getName());
+            // @todo
+            if (!$filesystem->has($parentVariant->getFilename())) {
+                throw new \InvalidArgumentException();
+            }
+
+            $filesystem->get($parentVariant->getFilename());
+            $result = $provider->processFromParent($media, $childVariant, $parentVariant, $filesystem);
+            $name = $namingStrategy->generateName($media, $childVariant, $filesystem);
+            $this->saveFileToFilesystem($result, $name, $filesystem, $childVariant);
+
+            //updates the variant in the media (to store the new values)
+            $media->addVariant($childVariant);
+
+            $this->persistenceAdapter->update($media);
+        }
+
         $provider = $this->getProvider($context->getProviderName(), $context->getProviderOptions());
         $variantInstance = $media->getVariantInstance($variant);
 

--- a/lib/Oryzone/MediaStorage/Provider/ProviderInterface.php
+++ b/lib/Oryzone/MediaStorage/Provider/ProviderInterface.php
@@ -95,6 +95,8 @@ interface ProviderInterface
      */
     public function process(MediaInterface $media, VariantInterface $variant, \SplFileInfo $source = NULL);
 
+    public function processFromParent($media, VariantInterface $variant, VariantInterface $parentVariant, Filesystem $filesystem);
+    
     /**
      * Renders a variant to HTML code. Useful for twig (or other template engines) integrations
      *


### PR DESCRIPTION
… needed when we generate new variants in the context after we process the initial variant tree. This is very early support and does not deal much with error check and fallbacks such as what happens when the parent source is not available. We also do not use media hints for different things such as the persistence adapter
